### PR TITLE
🐛 bug-fixing/KUPAY-29 - The place order button has been fixed to send events to amplitude

### DIFF
--- a/assets/woocommerce.js
+++ b/assets/woocommerce.js
@@ -119,19 +119,23 @@ if(document.getElementsByClassName('checkout-button').length > 0){
 
 }
 
+// whenever an order review mutation has occurred, the amplitude handler is added to the order review button
+const orderReview = document.getElementById('order_review')
+const orderReviewObserver = new MutationObserver(function (mutations) {
+    if(document.getElementById('place_order') != null){
 
-if(document.getElementById('place_order') != null){
-
-    document.getElementById('place_order').onclick = function() {
-        kupayEvent("CLICK", {
-            storeId: document.getElementById("kupay-app-id").value,
-            origin: "PLACE_ORDER",
-            platform: "WOOCOMMERCE"
-        })
+        document.getElementById('place_order').onclick = function() {
+            kupayEvent("CLICK", {
+                storeId: document.getElementById("kupay-app-id").value,
+                origin: "PLACE_ORDER",
+                platform: "WOOCOMMERCE"
+            })
+        }
+    
     }
+})
 
-}
-
+orderReviewObserver.observe(orderReview, { childList: true })
 
 
 if(document.getElementsByClassName('single_add_to_cart_button').length > 0){


### PR DESCRIPTION
whenever an order review mutation has occurred, the amplitude handler is added to the order review button
<img width="1180" alt="Screen Shot 2021-11-30 at 15 46 11" src="https://user-images.githubusercontent.com/93931576/144113071-1abe6b22-aa75-4688-b328-5704ab888051.png">

